### PR TITLE
Remove 'CheckBytes::layout' method from the 'const_generics' impl

### DIFF
--- a/bytecheck/src/lib.rs
+++ b/bytecheck/src/lib.rs
@@ -390,10 +390,6 @@ impl<T: CheckBytes<C>, C: ?Sized, const N: usize> CheckBytes<C> for [T; N] {
         }
         Ok(&*value)
     }
-
-    fn layout(value: *const Self, _: &mut C) -> Result<Layout, Self::Error> {
-        Ok(Layout::new::<Self>())
-    }
 }
 
 /// An error resulting from an invalid slice.


### PR DESCRIPTION
Hey :wave:!

I was recently using `bytecheck` and wanted to try the `const_generics` feature but got a compilation error because of an undefined `layout` method that was defined inside `impl CheckBytes<C> for [T; N]`. After removing it, everything seemed to compile again.