### PR TITLE
Rough first pass at adding github CI for multiple targets.

### DIFF
--- a/.github/matchers/rust.json
+++ b/.github/matchers/rust.json
@@ -1,0 +1,21 @@
+{
+"problemMatcher": [
+	{
+	"owner": "rust",
+	"pattern": [
+		{
+		"regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+		"severity": 1,
+		"message": 4,
+		"code": 3
+		},
+		{
+		"regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+		"file": 2,
+		"line": 3,
+		"column": 4
+		}
+	]
+	}
+]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - x86_64-unknown-netbsd
+          # - x86_64-unknown-netbsd
           # - wasm32-unknown-emscripten
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,6 @@ jobs:
           - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - i686-unknown-freebsd
-          - x86_64-unknown-freebsd
           - x86_64-unknown-netbsd
           - wasm32-unknown-emscripten
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           - s390x-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - x86_64-unknown-netbsd
-          - wasm32-unknown-emscripten
+          # - wasm32-unknown-emscripten
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
           - armv7-linux-androideabi
           - i686-linux-android
           - x86_64-linux-android
-          - aarch64-apple-ios
-          - x86_64-apple-ios
           - aarch64-unknown-linux-gnu
           - arm-unknown-linux-gnueabi
           - armv5te-unknown-linux-gnueabi
@@ -100,13 +98,13 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: -target ${{ matrix.target }} --verbose
+          args: --target ${{ matrix.target }} --verbose
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
           command: test
-          args: -target ${{ matrix.target }} --verbose
+          args: --target ${{ matrix.target }} --verbose
 
   test-native:
     name: Test (stable) - ${{ matrix.display_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,42 @@ jobs:
           command: test
           args: --target ${{ matrix.target }} --verbose
 
+  test-native-macos:
+    name: Test (stable) - ${{ matrix.target }}
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-ios
+          - x86_64-apple-ios
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: -target ${{ matrix.target }} --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: -target ${{ matrix.target }} --verbose
+
   test-native:
     name: Test (stable) - ${{ matrix.display_name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,111 @@
+name: Test Suite
+
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test-cross:
+    name: Test (stable) - ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        target:
+          - aarch64-linux-android
+          - arm-linux-androideabi
+          - armv7-linux-androideabi
+          - i686-linux-android
+          - x86_64-linux-android
+          - aarch64-apple-ios
+          - x86_64-apple-ios
+          - aarch64-unknown-linux-gnu
+          - arm-unknown-linux-gnueabi
+          - armv5te-unknown-linux-gnueabi
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-gnu
+          - i686-unknown-linux-musl
+          - mips-unknown-linux-gnu
+          - mips64-unknown-linux-gnuabi64
+          - mips64el-unknown-linux-gnuabi64
+          - mipsel-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - i686-unknown-freebsd
+          - x86_64-unknown-freebsd
+          - x86_64-unknown-netbsd
+          - wasm32-unknown-emscripten
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target ${{ matrix.target }} --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: test
+          args: --target ${{ matrix.target }} --verbose
+
+  test-native:
+    name: Test (stable) - ${{ matrix.display_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            display_name: Ubuntu 20.04
+          - os: macos-10.15
+            display_name: macOS 10.15
+          - os: windows-2019
+            display_name: Windows Server 2019
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        name: Cache Cargo registry + index
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - run: echo "::add-matcher::.github/matchers/rust.json"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,42 +70,6 @@ jobs:
           command: test
           args: --target ${{ matrix.target }} --verbose
 
-  test-native-macos:
-    name: Test (stable) - ${{ matrix.target }}
-    runs-on: macos-10.15
-    strategy:
-      matrix:
-        target:
-          - aarch64-apple-ios
-          - x86_64-apple-ios
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        name: Cache Cargo registry + index
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      - run: echo "::add-matcher::.github/matchers/rust.json"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.target }} --verbose
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target ${{ matrix.target }} --verbose
-
   test-native:
     name: Test (stable) - ${{ matrix.display_name }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This adds a new Github Actions workflow for testing.

Specifically, it does the following things:
- runs `cargo build --verbose` and `cargo test --verbose` for various targets
- for targets of which Github Actions has native workers (Ubuntu, Windows, macOS, all amd64
), it runs them "normally" (no cross-compilation)
- for targets which GHA has no native runner (ARM, MIPSEL, Android, etc) it uses `cross` to cross-compile the build/tests
- if tests are already running and new commits are pushed, the previous tests are cancelled before firing up the new ones

It also tries to do some caching of the Cargo index to hopefully keep builds speedy, since there's a lot more of them now.  Additionally, it specifies a [matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to provide a more native-ish experience of matching Rust error/warning output in the logs .

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>