### PR TITLE
moved UUID to major version

### DIFF
--- a/bytecheck/Cargo.toml
+++ b/bytecheck/Cargo.toml
@@ -25,7 +25,7 @@ simdutf8 = { version = "0.1", default-features = false, optional = true }
 # implementations should be moved into their respective crates over time. Before adding support for
 # another crate, please consider getting bytecheck support in the crate instead.
 
-uuid = { version = "1.0", optional = true }
+uuid = { version = "1", optional = true }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
To avoid dealing with separate versions of `uuid::Uuid` breaking downstream projects with their own `uuid` version:
```
error[E0277]: the trait bound `uuid::Uuid: bytecheck::CheckBytes<DefaultValidator<'_>>` is not satisfied
   --> crate/src/db/rkyv.rs:779:19
    |
779 |         let txn = rkyv::check_archived_root::<StructWithUuuid>(&data[..])?;
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `bytecheck::CheckBytes<DefaultValidator<'_>>` is not implemented for `uuid::Uuid`

```

The `uuid` crate has moved to track the major version.

I'm not sure if this is the right way to go about it, but this approach seemed to be the best way to deal with allowing downstream project to control their own version of `uuid::Uuid`. `uuid::Uuid` is somewhat special since it is more often than not a direct dependency as well as being invoked for trait implementations in upstream crates:

```toml
[dependencies]
bytecheck = { version = "0.6.9", default-features = false }
uuid = { version = "1.3.0", features = ["v4", "serde"] }
```

