### PR TITLE
added `workspace.package` values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,11 @@ members = [
     "bytecheck_derive",
     "bytecheck_test",
 ]
+
+[workspace.package]
+version = "0.7.0"
+authors = ["David Koloski <djkoloski@gmail.com>"]
+edition = "2021"
+license = "MIT"
+documentation = "https://docs.rs/bytecheck"
+repository = "https://github.com/djkoloski/bytecheck"

--- a/bytecheck/Cargo.toml
+++ b/bytecheck/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "bytecheck"
-version = "0.7.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Derive macro for bytecheck"
-license = "MIT"
 documentation = "https://docs.rs/bytecheck"
-repository = "https://github.com/djkoloski/bytecheck"
 keywords = ["bytecheck", "validation", "zero-copy", "rkyv"]
 categories = ["encoding"]
 readme = "crates-io.md"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck_derive = { version = "=0.7.0", path = "../bytecheck_derive", default-features = false }
+bytecheck_derive = { path = "../bytecheck_derive", default-features = false }
 ptr_meta = { version = "0.1", default-features = false }
 simdutf8 = { version = "0.1", default-features = false, optional = true }
 

--- a/bytecheck_derive/Cargo.toml
+++ b/bytecheck_derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "bytecheck_derive"
-version = "0.7.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Derive macro for bytecheck"
-license = "MIT"
 documentation = "https://docs.rs/bytecheck_derive"
-repository = "https://github.com/djkoloski/bytecheck"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bytecheck_test/Cargo.toml
+++ b/bytecheck_test/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "bytecheck_test"
-version = "0.7.0"
-authors = ["David Koloski <djkoloski@gmail.com>"]
-edition = "2018"
 description = "Test suite for bytecheck crates"
-license = "MIT"
-repository = "https://github.com/djkoloski/bytecheck"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytecheck = { version = "0.7", path = "../bytecheck", default-features = false }
+bytecheck = { path = "../bytecheck", default-features = false }
 ptr_meta = "~0.1.4"
 
 [features]


### PR DESCRIPTION
Followup on this discussion, https://github.com/rkyv/bytecheck/pull/27#discussion_r1104953163

Converted repo to use [`workspace.package` feature](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table)