### PR TITLE
Silence `unused_results` lint on derived impls

### DIFF
--- a/bytecheck_derive/src/lib.rs
+++ b/bytecheck_derive/src/lib.rs
@@ -199,6 +199,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
                 });
 
                 quote! {
+                    #[automatically_derived]
                     impl #impl_generics CheckBytes<__C> for #name #ty_generics #check_where {
                         type Error = StructCheckError;
 
@@ -241,6 +242,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
                 });
 
                 quote! {
+                    #[automatically_derived]
                     impl #impl_generics CheckBytes<__C> for #name #ty_generics #check_where {
                         type Error = TupleStructCheckError;
 
@@ -257,6 +259,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
             }
             Fields::Unit => {
                 quote! {
+                    #[automatically_derived]
                     impl #impl_generics CheckBytes<__C> for #name #ty_generics #impl_where_clause {
                         type Error = Infallible;
 
@@ -438,12 +441,14 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
 
                 struct Discriminant;
 
+                #[automatically_derived]
                 impl Discriminant {
                     #(#discriminant_const_defs)*
                 }
 
                 #(#variant_structs)*
 
+                #[automatically_derived]
                 impl #impl_generics CheckBytes<__C> for #name #ty_generics #check_where {
                     type Error = EnumCheckError<#repr>;
 
@@ -470,6 +475,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
     };
 
     Ok(quote! {
+        #[allow(unused_results)]
         const _: () = {
             use ::core::{convert::Infallible, marker::PhantomData};
             use bytecheck::{


### PR DESCRIPTION
Without this, if a crate specifies `#[deny(unused_results)]`, the trait cannot be derived, as it doesn't use the result of `check_bytes` when checking child fields.