### PR TITLE
Rust 1.57 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.11"
+version = "0.6.12"
 authors = ["David Koloski <djkoloski@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/bytecheck/src/lib.rs
+++ b/bytecheck/src/lib.rs
@@ -506,7 +506,7 @@ impl<T: fmt::Display> fmt::Display for SliceCheckError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SliceCheckError::CheckBytes { index, error } => {
-                write!(f, "check failed for slice index {index}: {error}")
+                write!(f, "check failed for slice index {}: {}", index, error)
             }
         }
     }
@@ -550,7 +550,7 @@ impl fmt::Display for StrCheckError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StrCheckError::Utf8Error(e) => write!(f, "utf8 error: {e}"),
+            StrCheckError::Utf8Error(e) => write!(f, "utf8 error: {}", e),
         }
     }
 }
@@ -598,7 +598,7 @@ impl fmt::Display for CStrCheckError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CStrCheckError::Utf8Error(e) => write!(f, "utf8 error: {e}"),
+            CStrCheckError::Utf8Error(e) => write!(f, "utf8 error: {}", e),
             CStrCheckError::MissingNullTerminator => write!(f, "missing null terminator"),
         }
     }
@@ -714,16 +714,16 @@ impl<T: fmt::Display> fmt::Display for EnumCheckError<T> {
                 inner,
             } => write!(
                 f,
-                "check failed for enum struct variant {variant_name}: {inner}"
+                "check failed for enum struct variant {}: {}", variant_name, inner
             ),
             EnumCheckError::InvalidTuple {
                 variant_name,
                 inner,
             } => write!(
                 f,
-                "check failed for enum tuple variant {variant_name}: {inner}"
+                "check failed for enum tuple variant {}: {}", variant_name, inner
             ),
-            EnumCheckError::InvalidTag(tag) => write!(f, "invalid tag for enum: {tag}"),
+            EnumCheckError::InvalidTag(tag) => write!(f, "invalid tag for enum: {}", tag),
         }
     }
 }

--- a/bytecheck_derive/src/lib.rs
+++ b/bytecheck_derive/src/lib.rs
@@ -366,7 +366,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
 
             let variant_structs = data.variants.iter().map(|v| {
                 let variant = &v.ident;
-                let variant_name = Ident::new(&format!("Variant{variant}"), v.span());
+                let variant_name = Ident::new(&format!("Variant{}", variant), v.span());
                 match v.fields {
                     Fields::Named(ref fields) => {
                         let fields = fields.named.iter().map(|f| {
@@ -403,7 +403,7 @@ fn derive_check_bytes(mut input: DeriveInput) -> Result<TokenStream, Error> {
 
             let check_arms = data.variants.iter().map(|v| {
                 let variant = &v.ident;
-                let variant_name = Ident::new(&format!("Variant{variant}"), v.span());
+                let variant_name = Ident::new(&format!("Variant{}", variant), v.span());
                 match v.fields {
                     Fields::Named(ref fields) => {
                         let checks = fields.named.iter().map(|f| {


### PR DESCRIPTION
We are trying to improve our support for rkyv in chrono (https://github.com/chronotope/chrono/pull/959), and things are getting complicated because there is no dependency resolution for our minimum MSRV of 1.57.

As I currently see it the easiest (maybe only) solution would be if there was one 0.6.x version of bytecheck (and bytecheck_derive as its dependency) that can compile with Rust 1.57.
Would you be okay with making such a release?
