### PR TITLE
`std` feature flag shouldn't enable `simdutf8` flag

### DIFF
--- a/bytecheck/Cargo.toml
+++ b/bytecheck/Cargo.toml
@@ -30,4 +30,4 @@ uuid = { version = "1.3", optional = true }
 [features]
 default = ["simdutf8", "std"]
 verbose = []
-std = ["ptr_meta/std", "bytecheck_derive/std", "simdutf8/std"]
+std = ["ptr_meta/std", "bytecheck_derive/std", "simdutf8?/std"]


### PR DESCRIPTION
`std` feature flag unconditionally enabled `simdutf8` dependency. Make it conditional.